### PR TITLE
Check if the splitAt param is used

### DIFF
--- a/src/__tests__/2.strings.js
+++ b/src/__tests__/2.strings.js
@@ -18,6 +18,6 @@ describe(`2.strings`, () => {
     it(`splitString: should divide a string into substrings and return an array`, () =>
       expect(stringsAnswers.splitString(`Jane,Doe,21`)).toEqual([ `Jane`, `Doe`, `21` ]));
     it(`splitString: should divide a string into substrings and return an array`, () =>
-      expect(stringsAnswers.splitString(`Jane,Doe,21`)).toEqual([ `Jane`, `Doe`, `21` ]));
+      expect(stringsAnswers.splitString(`Jane-Doe-21`, `-`)).toEqual([ `Jane`, `Doe`, `21` ]));
   });
 });


### PR DESCRIPTION
This makes sure students are using the splitAt param and not assuming the default of `,`